### PR TITLE
fix(password): do not generate passwords with the colon punctuation

### DIFF
--- a/password/password.go
+++ b/password/password.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const symbols = "~!@#$%^&*()_+-={}|[]<>?,./"
+
 // Secure password.
 type Secure struct {
 	generator *password.Generator
@@ -28,7 +30,12 @@ func (s *Secure) Generate(ctx context.Context, length Length) (string, error) {
 	l := int(length)
 	meta.WithAttribute(ctx, "password.generate.length", strconv.Itoa(l))
 
-	return password.Generate(l, 10, 10, false, false)
+	g, err := password.NewGenerator(&password.GeneratorInput{Symbols: symbols})
+	if err != nil {
+		return "", err
+	}
+
+	return g.Generate(l, 10, 10, false, false)
 }
 
 // Hash the password using bcrypt.

--- a/test/features/step_definitions/server/v1/transport/grpc/server_steps.rb
+++ b/test/features/step_definitions/server/v1/transport/grpc/server_steps.rb
@@ -100,6 +100,7 @@ Then('I should receive a valid password with length {int} for gRPC') do |length|
   length = 64 if length == 0
 
   expect(@response.meta.length).to be > 0
+  expect(@response.password.plain).not_to include(':')
   expect(@response.password.plain.length).to eq(length)
   expect(@response.password['hash'].length).to be > 0
 end
@@ -139,6 +140,7 @@ end
 Then('I should receive a valid access token with gRPC') do
   expect(@response.meta.length).to be > 0
   expect(@response.token.bearer.length).to be > 0
+  expect(@response.token.password.plain).not_to include(':')
   expect(@response.token.password.plain.length).to eq(64)
   expect(@response.token.password['hash'].length).to be > 0
 end

--- a/test/features/step_definitions/server/v1/transport/http/server_steps.rb
+++ b/test/features/step_definitions/server/v1/transport/http/server_steps.rb
@@ -106,10 +106,12 @@ Then('I should receive a valid password with length {int} for HTTP') do |length|
   expect(@response.code).to eq(200)
 
   resp = JSON.parse(@response.body)
+  pass = resp['password']['plain']
   length = 64 if length == 0
 
   expect(resp['meta'].length).to be > 0
-  expect(resp['password']['plain'].length).to eq(length)
+  expect(pass).not_to include(':')
+  expect(pass.length).to eq(length)
   expect(resp['password']['hash'].length).to be > 0
 end
 
@@ -157,10 +159,12 @@ Then('I should receive a valid access token with HTTP') do
   expect(@response.code).to eq(200)
 
   resp = JSON.parse(@response.body)
+  pass = resp['token']['password']['plain']
 
   expect(resp['meta'].length).to be > 0
   expect(resp['token']['bearer'].length).to be > 0
-  expect(resp['token']['password']['plain'].length).to eq(64)
+  expect(pass).not_to include(':')
+  expect(pass.length).to eq(64)
   expect(resp['token']['password']['hash'].length).to be > 0
 end
 


### PR DESCRIPTION
This breaks basic auth.