### PR TITLE
fix(security): allow to be setup using plaintext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	aidanwoods.dev/go-paseto v1.5.0
 	github.com/alexfalkowski/go-health v1.13.0
-	github.com/alexfalkowski/go-service v1.116.1
+	github.com/alexfalkowski/go-service v1.116.2
 	github.com/casbin/casbin/v2 v2.77.2
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/alexfalkowski/go-health v1.13.0 h1:DD+kWEPzn+sIhiv6mMeX1Wtab5sdtQpw8J6TsH/YVL8=
 github.com/alexfalkowski/go-health v1.13.0/go.mod h1:+8Q3zHywTGZl0VcsT2vr5edGOPDMVQIRbx7PboYKhxI=
-github.com/alexfalkowski/go-service v1.116.1 h1:zdYgkNUkb2a5QmnWmXBo3IvDFnXjGxrb+rZjADkScMs=
-github.com/alexfalkowski/go-service v1.116.1/go.mod h1:Y8XOhdCdsbrEiOjlhR23guBYQ/iOSmDZF6SAqZUZhms=
+github.com/alexfalkowski/go-service v1.116.2 h1:LQhOAE4tDULzYawLYKDX//R6ZfMLrX1mbQvTnKhJGUQ=
+github.com/alexfalkowski/go-service v1.116.2/go.mod h1:Y8XOhdCdsbrEiOjlhR23guBYQ/iOSmDZF6SAqZUZhms=
 github.com/arl/statsviz v0.6.0 h1:jbW1QJkEYQkufd//4NDYRSNBpwJNrdzPahF7ZmoGdyE=
 github.com/arl/statsviz v0.6.0/go.mod h1:0toboo+YGSUXDaS4g1D5TVS4dXs7S7YYT5J/qnW2h8s=
 github.com/avast/retry-go/v3 v3.1.1 h1:49Scxf4v8PmiQ/nY0aY3p0hDueqSmc7++cBbtiDGu2g=

--- a/server/v1/transport/grpc/grpc.go
+++ b/server/v1/transport/grpc/grpc.go
@@ -33,14 +33,18 @@ func Register(params RegisterParams) error {
 
 	v1.RegisterServiceServer(params.GRPCServer.Server, params.Server)
 
-	sec, err := grpc.WithClientSecure(params.GRPCConfig.Security)
-	if err != nil {
-		return err
-	}
-
 	opts := []grpc.ClientOption{
 		grpc.WithClientLogger(params.Logger), grpc.WithClientTracer(params.Tracer),
-		grpc.WithClientMetrics(params.Meter), sec, grpc.WithClientRetry(),
+		grpc.WithClientMetrics(params.Meter), grpc.WithClientRetry(),
+	}
+
+	if params.GRPCConfig.Security.IsEnabled() {
+		sec, err := grpc.WithClientSecure(params.GRPCConfig.Security)
+		if err != nil {
+			return err
+		}
+
+		opts = append(opts, sec)
 	}
 
 	conn, err := grpc.NewClient(ctx, fmt.Sprintf("localhost:%s", params.GRPCConfig.Port), params.GRPCConfig, opts...)

--- a/test/.config/client.yml
+++ b/test/.config/client.yml
@@ -16,6 +16,7 @@ transport:
   http:
     port: 8081
     security:
+      enabled: true
       cert_file: certs/cert.pem
       key_file: certs/key.pem
       client_cert_file: certs/client-cert.pem
@@ -28,6 +29,7 @@ transport:
     enabled: true
     port: 9091
     security:
+      enabled: true
       cert_file: certs/cert.pem
       key_file: certs/key.pem
       client_cert_file: certs/client-cert.pem

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -61,6 +61,7 @@ transport:
   http:
     port: 8080
     security:
+      enabled: true
       cert_file: certs/cert.pem
       key_file: certs/key.pem
       client_cert_file: certs/client-cert.pem
@@ -72,6 +73,7 @@ transport:
   grpc:
     enabled: true
     security:
+      enabled: true
       cert_file: certs/cert.pem
       key_file: certs/key.pem
       client_cert_file: certs/client-cert.pem


### PR DESCRIPTION
This is so we can use it during tests.